### PR TITLE
Creating welcome posts for each of the categories

### DIFF
--- a/install/data/categories.json
+++ b/install/data/categories.json
@@ -37,7 +37,7 @@
     },
 
     {
-        "name": "Assignment",
+        "name": "Assignments",
         "description": "View and Upload your assignments",
         "descriptionParsed": "<p>View and Upload your assignments</p>\n",
         "bgColor": "#DA70D6",

--- a/install/data/welcome_announcements.md
+++ b/install/data/welcome_announcements.md
@@ -1,4 +1,4 @@
-# Welcome to the announcements tab!
+# Welcome to the Announcements tab!
 
 You can click the "New Announcement" tab to get started. This allows you to make a new post to communicate with your students. 
 You can also view previous announcements and see what questions your students have.

--- a/install/data/welcome_announcements.md
+++ b/install/data/welcome_announcements.md
@@ -1,7 +1,7 @@
 # Welcome to the announcements tab!
 
-You can click the "New Assignment" tab to get started. This allows you to make a post and upload files for your students to see. 
-You can also view previous assignments and see what questions your students have.
+You can click the "New Announcement" tab to get started. This allows you to make a new post to communicate with your students. 
+You can also view previous announcements and see what questions your students have.
 
 ## Additional Resources
 

--- a/install/data/welcome_comments.md
+++ b/install/data/welcome_comments.md
@@ -1,0 +1,10 @@
+# Welcome to the Comments and Feedback tab!
+
+You can click the "New Comment" tab to get started. This allows you to make a new post to communicate with your students. 
+You can also view previous comments and see what questions your students have.
+
+## Additional Resources
+
+* [NodeBB Documentation](https://docs.nodebb.org)
+* [Community Support Forum](https://community.nodebb.org)
+* [Project repository](https://github.com/nodebb/nodebb)

--- a/src/install.js
+++ b/src/install.js
@@ -513,7 +513,7 @@ async function createAnnouncementPost() {
 
     const [content, numTopics] = await Promise.all([
         fs.promises.readFile(path.join(__dirname, '../', 'install/data/welcome_announcements.md'), 'utf8'),
-        db.getObjectField('announcement', 'topicCount'), //Changed global to assignment (I think it's some sort of hashmap)
+        db.getObjectField('announcement', 'topicCount'), //Changed announcement to assignment (I think it's some sort of hashmap)
     ]);
 
     if (!parseInt(numTopics, 10)) {
@@ -521,7 +521,27 @@ async function createAnnouncementPost() {
         await Topics.post({
             uid: 1,
             cid: 1,
-            title: 'Welcome to the Assignments tab!',
+            title: 'Welcome to the Announcements tab!',
+            content: content,
+        });
+    }
+}
+
+async function createCommentsPost() {
+    const db = require('./database');
+    const Topics = require('./topics');
+
+    const [content, numTopics] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, '../', 'install/data/welcome_comments.md'), 'utf8'),
+        db.getObjectField('comments', 'topicCount'), //Changed global to comments (I think it's some sort of hashmap)
+    ]);
+
+    if (!parseInt(numTopics, 10)) {
+        console.log('Creating welcome post!');
+        await Topics.post({
+            uid: 1,
+            cid: 4,
+            title: 'Welcome to the Comments and Feedback tab!',
             content: content,
         });
     }
@@ -618,6 +638,8 @@ install.setup = async function () {
         await createMenuItems();
         await createWelcomePost();
         await createAssignmentPost();
+        await createAnnouncementPost();
+        await createCommentsPost();
         await enableDefaultPlugins();
         await setCopyrightWidget();
         await copyFavicon();

--- a/src/install.js
+++ b/src/install.js
@@ -507,6 +507,26 @@ async function createAssignmentPost() {
     }
 }
 
+async function createAnnouncementPost() {
+    const db = require('./database');
+    const Topics = require('./topics');
+
+    const [content, numTopics] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, '../', 'install/data/welcome_announcements.md'), 'utf8'),
+        db.getObjectField('announcement', 'topicCount'), //Changed global to assignment (I think it's some sort of hashmap)
+    ]);
+
+    if (!parseInt(numTopics, 10)) {
+        console.log('Creating welcome post!');
+        await Topics.post({
+            uid: 1,
+            cid: 1,
+            title: 'Welcome to the Assignments tab!',
+            content: content,
+        });
+    }
+}
+
 async function enableDefaultPlugins() {
     console.log('Enabling default plugins');
 


### PR DESCRIPTION
Fixes issue #13 
I created welcome posts for each of the different tabs to give the user instructions on how to use them. Here is an example of what the assignments tab now looks like:
![image](https://github.com/CMU-313/fall23-nodebb-khrom/assets/43318621/7736b3a1-a668-4e61-9715-b0a06d55f640)
