### PR TITLE
Create Assignment Button for only Admin

### DIFF
--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -82,7 +82,7 @@ topicsController.get = async function getTopic(req, res, next) {
 
     topics.modifyPostsByPrivilege(topicData, userPrivileges);
     topicData.tagWhitelist = categories.filterTagWhitelist(topicData.tagWhitelist, userPrivileges.isAdminOrMod);
-
+    
     topicData.privileges = userPrivileges;
     topicData.topicStaleDays = meta.config.topicStaleDays;
     topicData['reputation:disabled'] = meta.config['reputation:disabled'];

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -82,7 +82,6 @@ topicsController.get = async function getTopic(req, res, next) {
 
     topics.modifyPostsByPrivilege(topicData, userPrivileges);
     topicData.tagWhitelist = categories.filterTagWhitelist(topicData.tagWhitelist, userPrivileges.isAdminOrMod);
-    
     topicData.privileges = userPrivileges;
     topicData.topicStaleDays = meta.config.topicStaleDays;
     topicData['reputation:disabled'] = meta.config['reputation:disabled'];

--- a/themes/nodebb-theme-persona/templates/category.tpl
+++ b/themes/nodebb-theme-persona/templates/category.tpl
@@ -7,15 +7,14 @@
 <div class="row">
     <div class="category <!-- IF widgets.sidebar.length -->col-lg-9 col-sm-12<!-- ELSE -->col-lg-12<!-- ENDIF widgets.sidebar.length -->">
         <!-- IMPORT partials/category/subcategory.tpl -->
-
         <div class="topic-list-header clearfix">
             <!-- IF privileges.topics:create -->
             <a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary" data-ajaxify="false" role="button">[[category:new_topic_button]]</a>
             <!-- ELSE -->
                 <!-- IF !loggedIn -->
-                <a component="category/post/guest" href="{config.relative_path}/login" class="btn btn-primary">[[category:guest-login-post]]</a>
+            <a component="category/post/guest" href="{config.relative_path}/login" class="btn btn-primary">[[category:guest-login-post]]</a>
                 <!-- ENDIF !loggedIn -->
-            <!-- ENDIF privileges.topics:create -->
+            <!-- ENDIF privileges.topics:create-->
 
             <a href="{url}" class="inline-block">
                 <div class="alert alert-warning hide" id="new-topics-alert"></div>
@@ -27,6 +26,7 @@
                 <!-- IMPORT partials/category/tools.tpl -->
             </span>
         </div>
+       
 
         <!-- IF !topics.length -->
         <!-- IF privileges.topics:create -->

--- a/themes/nodebb-theme-persona/templates/partials/category/subcategory.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category/subcategory.tpl
@@ -5,7 +5,6 @@
     {{{ else }}}
     <p>[[category:subcategories]]</p>
     {{{ end }}}
-
     <ul component="category/subcategory/container" class="categories" itemscope itemtype="http://www.schema.org/ItemList">
         {{{each children}}}
         <!-- IMPORT partials/categories/item.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/category/tools.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category/tools.tpl
@@ -7,6 +7,9 @@
     </button>
     <ul class="dropdown-menu pull-right">
         <li>
+            <a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary" data-ajaxify="false" role="button" style="background-color: white;">[[category:new_topic_button]]</a>
+        </li>
+        <li>
             <a component="topic/mark-unread-for-all" href="#">
                 <i class="fa fa-fw fa-inbox"></i> [[topic:thread_tools.markAsUnreadForAll]]
             </a>

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -1,6 +1,6 @@
 <ul component="category" class="topic-list" itemscope itemtype="http://www.schema.org/ItemList" data-nextstart="{nextStart}" data-set="{set}">
     {{{each topics}}}
-    <li component="category/topic" class="row clearfix category-item {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl -->>
+    <li component="category/topic" class="row clearfix category-item {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl -->
         <link itemprop="url" content="{config.relative_path}/topic/{../slug}" />
         <meta itemprop="name" content="{function.stripTags, ../title}" />
         <meta itemprop="itemListOrder" content="descending" />

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -18,7 +18,6 @@
                     <span component="topic/title">{title}</span>
                 </span>
             </h1>
-
             <div class="topic-info clearfix">
                 <div class="category-item inline-block">
                     <div role="presentation" class="icon pull-left" style="{function.generateCategoryBackground, category}">
@@ -65,7 +64,6 @@
             {{{each posts}}}
                 <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
                     <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
-
                     <meta itemprop="datePublished" content="{posts.timestampISO}">
                     <meta itemprop="dateModified" content="{posts.editedISO}">
 


### PR DESCRIPTION
Fixes Issue #12 
Create a create topic option within the topic tools dropdown menu that only admin can see. When the admin clicks the topic tools dropdown option and clicks on new topic, it will show the same abilities the new topic button has. 
-created change in the tools.tpl file for it to be shown